### PR TITLE
Fixed missing headers in zip_file.cpp

### DIFF
--- a/zip_file.cpp
+++ b/zip_file.cpp
@@ -2,6 +2,7 @@
 #include <cassert>
 #include <cstring>
 #include <fstream>
+#include <iterator>
 
 #ifdef _WIN32
 #define NOMINMAX


### PR DESCRIPTION
I head some problems compiling with Visual Studio 14 because of the `iterator`header was missing, which contains `std::back_inserter` used in `zip_file.cpp`. Fix was simple :-)