### PR TITLE
Correct invalid std::size_t conversions from

### DIFF
--- a/zip_file.hpp
+++ b/zip_file.hpp
@@ -5580,7 +5580,7 @@ private:
                 
                 mz_zip_reader_end(archive_.get());
                 
-                archive_->m_pWrite = &detail::write_callback;
+                archive_->m_pWrite = reinterpret_cast<mz_file_write_func>(&detail::write_callback);
                 archive_->m_pIO_opaque = &buffer_;
                 buffer_ = std::vector<char>();
                 
@@ -5608,7 +5608,7 @@ private:
                 break;
         }
 
-        archive_->m_pWrite = &detail::write_callback;
+        archive_->m_pWrite = reinterpret_cast<mz_file_write_func>(&detail::write_callback);
         archive_->m_pIO_opaque = &buffer_;
 
         if(!mz_zip_writer_init(archive_.get(), 0))


### PR DESCRIPTION
Compilation prior to this change failed w/ message
invalid conversion from ‘std::size_t (*)(void*, uint64_t, const void*, std::size_t) {aka long unsigned int (*)(void*, long unsigned int, const void*, long unsigned int)}’ to ‘mz_file_write_func {aka long unsigned int (*)(void*, long long unsigned int, const void*, long unsigned int)}’ [-fpermissive]
         archive_->m_pWrite = &detail::write_callback;