### PR TITLE
Undefine 'min' and 'max' to avoid conflicts with defines from 'minwin…

### DIFF
--- a/zip_file.hpp
+++ b/zip_file.hpp
@@ -21,6 +21,8 @@
 // @license: http://www.opensource.org/licenses/mit-license.php
 
 #pragma once
+#undef min
+#undef max
 
 #include <algorithm>
 #include <cstdint>


### PR DESCRIPTION
Windows applications might have included _minwindef.h_ which already defines `min` and `max` thus issuing compilation errors.

The easiest workaround is to undefine such symbols before redefining them through `<algorithm>`.